### PR TITLE
ADD proxy to port 8080 in development and api integration for user registration

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,5 +1,6 @@
 {
   "name": "feminist-bible-phase-2",
+  "proxy": "http://localhost:8080",
   "version": "0.1.0",
   "private": true,
   "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
+    "axios": "^0.21.1",
     "node-sass": "^4.14.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/frontend/src/pages/Registration.js
+++ b/frontend/src/pages/Registration.js
@@ -2,6 +2,8 @@ import React, { Component } from 'react'
 import { Input, WithPasswordStrength } from '../components/input';
 import { Link } from 'react-router-dom';
 
+const womenImg = require('../images/women.png').default;
+
 export default class Registration extends Component {
   state = {
     email: '',
@@ -89,7 +91,7 @@ export default class Registration extends Component {
             </div>
             <div className="cell large-8">
               <div className="registration-page__illustration-wrapper">
-                <img src={require('../images/women.png')} className="registration-page__illustration" alt="Illustration of women"/>
+                <img src={womenImg} className="registration-page__illustration" alt="Illustration of women"/>
               </div>
             </div>
           </div>

--- a/frontend/src/pages/Registration.js
+++ b/frontend/src/pages/Registration.js
@@ -1,16 +1,21 @@
 import React, { Component } from 'react'
 import { Input, WithPasswordStrength } from '../components/input';
 import { Link } from 'react-router-dom';
+import Axios from "axios";
 
 const womenImg = require('../images/women.png').default;
 
 export default class Registration extends Component {
   state = {
+    name: '',
     email: '',
+    phone: '',
     password: '',
     cpassword: '',
     errors: {
+      name: '',
       email: '',
+      phone: '',
       password: '',
       cpassword: ''
     }
@@ -21,11 +26,20 @@ export default class Registration extends Component {
     e.preventDefault();
     this.setState(prevState => ({ ...prevState, errors: { email: '', password: '', cpassword: '' } }))
     // validation
-    const { email, password, cpassword } = this.state;
+    const { name, email, phone, password, cpassword } = this.state;
+    //name
+    if (!name) {
+      this.setState(prevState => ({ ...prevState, errors: { ...prevState.errors, name: 'Name cannot be empty' } }));
+      return;
+    }
     // email
     const emailTest = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
     if (!emailTest.test(email)) {
       this.setState(prevState => ({ ...prevState, errors: { ...prevState.errors, email: 'Email is not valid.' } }));
+      return;
+    }
+    if(!phone || phone.length < 10) {
+      this.setState(prevState => ({ ...prevState, errors: { ...prevState.errors, phone: 'Mobile No. cannot be empty or less than 10 digits.' } }));
       return;
     }
     // password
@@ -42,12 +56,33 @@ export default class Registration extends Component {
       return;
     }
     // registeration logic
-    alert('registered.')
+    this.registerUser();
   }
 
   changeHandler = e => {
     e.persist();
     this.setState(prevState => ({ ...prevState, [e.target.name]: e.target.value }));
+  }
+
+  registerUser = async (user) => {
+    // add user to backend
+    try {
+      const { name, email, phone, password, cpassword: passwordConfirm} = this.state;
+      const res = await Axios({
+        url: "/api/auth/signup",
+        method: "POST",
+        data:  {
+          name,
+          email,
+          phone,
+          password,
+          passwordConfirm
+        }
+      });
+      alert("Registered...")
+    } catch (error) {
+      alert(`Something went wrong! \n ${error.response.data.msg}`)
+    }
   }
 
 
@@ -62,12 +97,28 @@ export default class Registration extends Component {
               <h2 className="registration-page__title">Register</h2>
               <form onSubmit={this.registerHandler} className="registration-page__form">
                 <Input
+                  label="Name"
+                  type="text"
+                  name="name"
+                  placeholder="John Doe"
+                  onChange={this.changeHandler}
+                  error={errors.name}
+                />
+                <Input
                   label="Email Address"
                   type="email"
                   name="email"
                   placeholder="username@example.com"
                   onChange={this.changeHandler}
                   error={errors.email}
+                />
+                <Input
+                  label="Mpbile Number"
+                  type="tel"
+                  name="phone"
+                  placeholder="+91 8563214752"
+                  onChange={this.changeHandler}
+                  error={errors.phone}
                 />
                 <WithPasswordStrength
                   label="Create Password"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2807,6 +2807,13 @@ axe-core@^4.0.2:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.0.2.tgz#c7cf7378378a51fcd272d3c09668002a4990b1cb"
   integrity sha512-arU1h31OGFu+LPrOLGZ7nB45v940NMDMEJeNmbutu57P+UFDVnkZg3e+J1I2HJRZ9hT7gO8J91dn/PMrAiKakA==
 
+axios@^0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
+  dependencies:
+    follow-redirects "^1.10.0"
+
 axobject-query@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
@@ -5483,6 +5490,11 @@ follow-redirects@^1.0.0:
   integrity sha512-4eyLK6s6lH32nOvLLwlIOnr9zrL8Sm+OvW4pVTJNoXeGzYIkHVf+pADQi+OJ0E67hiuSLezPVPyBcIZO50TmmQ==
   dependencies:
     debug "^3.0.0"
+
+follow-redirects@^1.10.0:
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.1.tgz#5f69b813376cee4fd0474a3aba835df04ab763b7"
+  integrity sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==
 
 for-in@^0.1.3:
   version "0.1.8"


### PR DESCRIPTION

**Description** <br/>.
Updated package.json to proxy requests from frontend react dev server to backend node API.

This eliminates the unnecessary addition of **http://localhost:8080**/some-api-route while requesting from the frontend.
Also, we will no longer need to worry about mapping request URLs to a backend as we can use a reverse proxy to host our frontend. 