### PR TITLE
feat: Make Navbar sticky.

### DIFF
--- a/frontend/src/components/Header/header.module.scss
+++ b/frontend/src/components/Header/header.module.scss
@@ -4,8 +4,11 @@
 // Header bar
 .header{
     height:80px;
+    position: fixed;
+    top: 0;
     background-color:$yellow-bg;
     border-bottom:1px solid rgba(171, 29, 121, 0.3);
+    width: 100%;
   
     &__logo{
       height:46px; margin-top:17px;

--- a/frontend/src/components/Header/header.module.scss
+++ b/frontend/src/components/Header/header.module.scss
@@ -4,8 +4,10 @@
 // Header bar
 .header{
     height:80px;
+    
     position: fixed;
     top: 0;
+    
     background-color:$yellow-bg;
     border-bottom:1px solid rgba(171, 29, 121, 0.3);
     width: 100%;

--- a/frontend/src/components/Header/header.module.scss
+++ b/frontend/src/components/Header/header.module.scss
@@ -11,6 +11,7 @@
     background-color:$yellow-bg;
     border-bottom:1px solid rgba(171, 29, 121, 0.3);
     width: 100%;
+    z-index: 9999;
   
     &__logo{
       height:46px; margin-top:17px;

--- a/frontend/src/css/settings/_global.scss
+++ b/frontend/src/css/settings/_global.scss
@@ -4,6 +4,7 @@
 }
 
 body{
+  padding: 80px 0 0;
   margin:0;
   overflow-x: hidden;
 }


### PR DESCRIPTION
### Fixes #208 

**Description** <br/>
Made the Navbar sticky.

Steps:
1. Fixed the position of the header at the top of the page.
2. Added padding at the top equal to the height of the header so as to avoid any webpage element being hidden behind the header.

**Screenshots** <br/>
![Screenshot (181)](https://user-images.githubusercontent.com/59606099/111207881-2ab3be00-85f0-11eb-9c47-5868e1977aeb.png)

**Addition Information (if any)** <br/>
none

