### PR TITLE
ci: separate development and production env

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,7 +2,11 @@
 # copy below lines and store them inside `.env` along with their values 
 # prior to starting the project
 
+# For development, name the file .env
+# For production, name the file .env.production
+
 DATABASE_URI=`Put Database URI here`
 JWT_EXPIRES_IN=`JWT expiry time`
 JWT_SECRET=`JWT Secret`
 JWT_COOKIE_EXPIRES_IN=`cookie expiry time`
+PORT=`Put numeric port here`

--- a/backend/README.md
+++ b/backend/README.md
@@ -59,8 +59,9 @@ issue if you find anything wrong
 1. `cd` to locally locally cloned repository
 2. `cd` to back-end dir (i.e. fb-phase2-backend)
 3. run `yarn`. this should install all required dependencies
-4. copy `.env.example` to `.env` and fill it with appropriate details
-5. start project with `yarn dev`
+4. For development, copy `.env.example` to `.env` and fill it with appropriate details
+5. For production, copy `.env.example` to `.env.production` and fill it with appropriate details
+6. start project with `yarn dev`
 
 before making a PR, make sure test cases are not failing. to run all test cases
 from specs/ dir, just run `yarn test`. you shall see a test coverage report

--- a/backend/config/dotenv.js
+++ b/backend/config/dotenv.js
@@ -1,2 +1,24 @@
+const fs = require('fs');
 const path = require('path');
-require('dotenv').config({ path: path.resolve('.env') });
+
+// check if environment is set as development
+if (process.env.NODE_ENV === "development") {
+    // check if .env file exists
+    if (!fs.existsSync(path.resolve('.env'))) {
+        throw new TypeError('.env File Not Found. Forgot to create one?');
+    }
+
+    // load the .env file (for development)
+    require('dotenv').config({ path: path.resolve(`.env`) });
+} 
+
+// default the environment to production
+else {
+    // check if .env.production file exists
+    if (!fs.existsSync(path.resolve('.env.production'))) {
+        throw new TypeError('.env File Not Found. Forgot to create one?');
+    }
+
+    // load the .env.production file (for production)
+    require('dotenv').config({ path: path.resolve(`.env.production`) });
+}

--- a/backend/config/dotenv.js
+++ b/backend/config/dotenv.js
@@ -3,22 +3,24 @@ const path = require('path');
 
 // check if environment is set as development
 if (process.env.NODE_ENV === "development") {
+    /*
     // check if .env file exists
     if (!fs.existsSync(path.resolve('.env'))) {
         throw new TypeError('.env File Not Found. Forgot to create one?');
     }
-
+    */
     // load the .env file (for development)
     require('dotenv').config({ path: path.resolve(`.env`) });
 } 
 
 // default the environment to production
 else {
+    /*
     // check if .env.production file exists
     if (!fs.existsSync(path.resolve('.env.production'))) {
         throw new TypeError('.env File Not Found. Forgot to create one?');
     }
-
+    */
     // load the .env.production file (for production)
     require('dotenv').config({ path: path.resolve(`.env.production`) });
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,9 +4,9 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "node server.js",
-    "dev": "nodemon server.js",
-    "test": "nyc mocha --recursive test",
+    "start": "cross-env NODE_ENV=production node server.js",
+    "dev": "cross-env NODE_ENV=development nodemon server.js",
+    "test": "cross-env NODE_ENV=development nyc mocha --recursive test",
     "preci": "rm -fr node_modules",
     "ci": "yarn install --frozen-lockfile"
   },
@@ -20,6 +20,7 @@
     "express": "^4.17.1",
     "express-mongo-sanitize": "^2.0.0",
     "express-rate-limit": "^5.1.3",
+    "cross-env": "^7.0.3",
     "helmet": "^4.1.1",
     "jsonwebtoken": "^8.5.1",
     "mongoose": "^5.11.19",

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -951,7 +951,14 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
-cross-spawn@^7.0.0:
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
+cross-spawn@^7.0.0, cross-spawn@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
### Fixes #260 

**Description** <br/>
In the mention issue, I had proposed to have an `.env.production` and a `.env.development` instead of just a single `.env` file for both development + testing and production purposes. Since many collaborators and contributors are actively developing the project, I decided to keep `.env.development` as `.env`.

**Change Log:**
- I have installed a new npm package named cross-env. It helps us to set the node environment inside npm scripts which can then be used to load equivalent configs for development or production, based on the environment. (View Screenshot for reference)
- `/config/dotenv.js` has been updated that checks the node environment and loads equivalent `.env` file
- `readme.md` in `/backend` has been updated with instructions for the .env setup for production and development separately

**Screenshots** <br/>
![image](https://user-images.githubusercontent.com/52620158/112792306-d513f280-9080-11eb-8718-42b74d05cb3f.png)


**Addition Information (if any)** <br/>
I will be writing the tests once this PR gets approved. Let me know if I can use the npm package named `chai` for testing.
