### PR TITLE
Fixed Typo in Registration Page

### DIFF
--- a/frontend/src/pages/Registration/Registration.jsx
+++ b/frontend/src/pages/Registration/Registration.jsx
@@ -115,7 +115,7 @@ export class Registration extends Component {
                   error={errors.email}
                 />
                 <Input
-                  label="Mpbile Number"
+                  label="Mobile Number"
                   type="tel"
                   name="phone"
                   placeholder="+91 8563214752"


### PR DESCRIPTION
### Fixes #331 

**Description** <br/>
Fixed the typo on the registration page ( the spelling of "Mobile Number" )

**Screenshots** <br/>
![Capture1](https://user-images.githubusercontent.com/23502662/115346239-8cf27680-a1cd-11eb-9353-f5aece77ba8d.PNG)

